### PR TITLE
Add support for message fields and payload in slack notification.

### DIFF
--- a/src/main/java/com/oneops/antenna/cache/SinkSubscriberLoader.java
+++ b/src/main/java/com/oneops/antenna/cache/SinkSubscriberLoader.java
@@ -20,7 +20,6 @@ package com.oneops.antenna.cache;
 
 import com.google.common.cache.CacheLoader;
 import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 import com.oneops.antenna.domain.*;
 import com.oneops.antenna.domain.SlackSubscriber.Channel;
 import com.oneops.antenna.domain.SlackSubscriber.Format;
@@ -150,6 +149,8 @@ public class SinkSubscriberLoader extends CacheLoader<SinkKey, List<BasicSubscri
         // Text format attribute (Hash) format is "{'label[|level]' : 'msg', ....}"
         @SuppressWarnings("unchecked")
         Map<String, String> formats = gson.fromJson(sink.getAttribute("text_formats").getDfValue(), Map.class);
+        // Include raw notification fields.
+        boolean includeFields = Boolean.valueOf(sink.getAttribute("notification_fields").getDfValue());
 
         // Use a linked list to preserve the order when applying message format.
         List<Channel> chanList = Arrays.stream(channels)
@@ -165,6 +166,7 @@ public class SinkSubscriberLoader extends CacheLoader<SinkKey, List<BasicSubscri
 
         slackSink.setChannels(chanList);
         slackSink.setFormats(fmtList);
+        slackSink.setFieldsOn(includeFields);
         return slackSink;
     }
 

--- a/src/main/java/com/oneops/antenna/domain/SlackSubscriber.java
+++ b/src/main/java/com/oneops/antenna/domain/SlackSubscriber.java
@@ -28,6 +28,7 @@ public class SlackSubscriber extends BasicSubscriber {
 
     private List<Channel> channels;
     private List<Format> formats;
+    private boolean fieldsOn;
 
     public List<Channel> getChannels() {
         return channels;
@@ -45,11 +46,20 @@ public class SlackSubscriber extends BasicSubscriber {
         this.formats = formats;
     }
 
+    public boolean isFieldsOn() {
+        return fieldsOn;
+    }
+
+    public void setFieldsOn(boolean fieldsOn) {
+        this.fieldsOn = fieldsOn;
+    }
+
     @Override
     public String toString() {
         return "SlackSubscriber{" +
                 "channels=" + channels +
                 ", formats=" + formats +
+                ", fieldsOn=" + fieldsOn +
                 '}';
     }
 

--- a/src/main/java/com/oneops/antenna/senders/slack/SlackWebClient.java
+++ b/src/main/java/com/oneops/antenna/senders/slack/SlackWebClient.java
@@ -75,12 +75,12 @@ public interface SlackWebClient {
      * @see #postMessage(String, String, String, Map)
      */
     default Call<SlackResponse> postMessage(String token, String channel, String text, List<Attachment> attachments) {
-        Map<String, Object> options = new HashMap<>(4);
-        options.put("attachments", gson.toJson(attachments));
+        Map<String, Object> options = new HashMap<>(5);
         options.put("username", BOT_NAME);
         options.put("as_user", false);
         options.put("icon_emoji", ":oneops:");
         options.put("mrkdwn", true);
+        options.put("attachments", gson.toJson(attachments));
         // options.put("parse", "full");
         return postMessage(token, channel, text, options);
     }


### PR DESCRIPTION
Provided an option in slack notification sink to include the raw notification message fields and payload info when sending to the corresponding slack channels.

<img width="544" alt="slack message" src="https://cloud.githubusercontent.com/assets/356994/22845553/008f2d8c-ef98-11e6-9ec9-6c6c77a532f5.png">

<img width="600" alt="notificationfields" src="https://cloud.githubusercontent.com/assets/356994/22845548/f9e7f98c-ef97-11e6-9e13-46a4efc69c3c.png">

